### PR TITLE
Better backup file name format

### DIFF
--- a/Omega/src/com/saggitt/omega/backup/BackupFile.kt
+++ b/Omega/src/com/saggitt/omega/backup/BackupFile.kt
@@ -288,7 +288,7 @@ class BackupFile(context: Context, val uri: Uri) {
         val EXTRA_MIME_TYPES = arrayOf(MIME_TYPE, "application/x-zip", "application/octet-stream")
 
         const val WALLPAPER_FILE_NAME = "wallpaper.png"
-        val timestampFormat = SimpleDateFormat("dd-MM-yyyy HH:mm:ss", Locale.US)
+        val timestampFormat = SimpleDateFormat("neo_launcher_backup_yyyy-MM-dd_HH.mm.ss", Locale.US)
 
         fun getFolder(context: Context): File {
             val folder = File(

--- a/Omega/src/com/saggitt/omega/backup/NewBackupFragment.kt
+++ b/Omega/src/com/saggitt/omega/backup/NewBackupFragment.kt
@@ -258,7 +258,7 @@ class NewBackupFragment : Fragment() {
     }
 
     private fun getTimestamp(): String {
-        val simpleDateFormat = SimpleDateFormat("dd-MM-yyyy hh:mm:ss", Locale.US)
+        val simpleDateFormat = SimpleDateFormat("neo_launcher_backup_yyyy-MM-dd_HH.mm.ss", Locale.US)
         return simpleDateFormat.format(Date())
     }
 }


### PR DESCRIPTION
Hi,

`dd-MM-yyyy HH:mm:ss` doesn't look good in my opinion, for several reasons:

1. I created a backup on July 31st, which was saved as `31-07-2022 21_07_23.zbk`. I created another backup today, which was saved as `07-08-2022 14_10_47.zbk`. As a result, today's backup is listed first in my backup directory, which doesn't make sense to me. It should be the opposite, the oldest backup first and the newest one last. Switching to `yyyy-MM-dd` solves this.

2. Why using `:` since it's replaced with `_` during backup creation?

3. Why a space between date and time? this is unconventional.

4. Just having date and time in filename is a bit vague, so I thought that adding `neo_launcher_backup` at the beginning would help in that regard.

Cheers.