### PR TITLE
Custom widget corner radius in the compose preferences

### DIFF
--- a/Omega/src/com/saggitt/omega/preferences/BasePreferences.kt
+++ b/Omega/src/com/saggitt/omega/preferences/BasePreferences.kt
@@ -318,10 +318,12 @@ abstract class BasePreferences(context: Context) :
         onChange
     ) {
 
-        override fun onGetValue(): Float = dpToPx(sharedPrefs.getFloat(getKey(), defaultValue))
+        override fun onGetValue() = pxToDp(sharedPrefs.getFloat(getKey(), dpToPx(defaultValue)))
+
+        fun getValueInPixels() = sharedPrefs.getFloat(getKey(), dpToPx(defaultValue))
 
         override fun onSetValue(value: Float) {
-            edit { putFloat(getKey(), pxToDp(value)) }
+            edit { putFloat(getKey(), dpToPx(value)) }
         }
     }
 

--- a/Omega/src/com/saggitt/omega/preferences/OmegaPreferences.kt
+++ b/Omega/src/com/saggitt/omega/preferences/OmegaPreferences.kt
@@ -337,14 +337,9 @@ class OmegaPreferences(val context: Context) : BasePreferences(context) {
         titleId = R.string.title_desktop_widget_corner_radius,
         defaultValue = 16f,
         maxValue = 24f,
-        minValue = 0f,
-        steps = 24,
-        specialOutputs = {
-            when {
-                it < 0f -> context.getString(R.string.automatic_short)
-                else -> "${it.roundToInt()}dp"
-            }
-        },
+        minValue = 1f,
+        steps = 22,
+        specialOutputs = { "${it.roundToInt()}dp" },
         onChange = recreate
     )
     val desktopMultilineLabel = BooleanPref(

--- a/src/com/android/launcher3/widget/RoundedCornerEnforcement.java
+++ b/src/com/android/launcher3/widget/RoundedCornerEnforcement.java
@@ -105,10 +105,10 @@ public class RoundedCornerEnforcement {
     public static float computeEnforcedRadius(@NonNull Context context) {
         Resources res = context.getResources();
         if (!Utilities.ATLEAST_S) {
-            return Utilities.getOmegaPrefs(context).getDesktopWidgetRadius().onGetValue();
+            return Utilities.getOmegaPrefs(context).getDesktopWidgetRadius().getValueInPixels();
         }
         float systemRadius = res.getDimension(android.R.dimen.system_app_widget_background_radius);
-        float configuredRadius = Utilities.getOmegaPrefs(context).getDesktopWidgetRadius().onGetValue();
+        float configuredRadius = Utilities.getOmegaPrefs(context).getDesktopWidgetRadius().getValueInPixels();
         return Math.min(configuredRadius, systemRadius);
     }
 


### PR DESCRIPTION
This PR fixes the widget radius preference option with the newer compose style preferences.

Tested as working on my Pixel 5 with Android 13 and on the emulator.

Note:
- "Override window corner radius" must be enabled, otherwise the launcher does not change the corner radius on any widget. 
    - Given that this is how Neo Launcher currently works, I have left that requirement unchanged. If this isn't intended, I can look at decoupling that.
- Some widget, such as the Google Calendar widget, handle their own widget corner radius sizes rather than the launcher configuring them, so they are affected by this preference option. I am looking into a way to force override the corner radius of this style of widget, but this requires modifying the internal style of the widget I need to ensure there is no unintended consequences from doing this.