### PR TITLE
chore: update installation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Our builds are available on:
 
 - **Github**: [Releases](https://github.com/NeoApplications/Neo-Launcher/releases).
 
-- **F-Droid**: On **[IzzyOnDroid repo](https://apt.izzysoft.de/fdroid/repo?fingerprint=3BF0D6ABFEAE2F401707B6D966BE743BF0EEE49C2561B9BA39073711F628937A)** or **[our own repo (only for test)](https://raw.githubusercontent.com/nonaybay/newomega/master/fdroid/repo)**.
+- **F-Droid**: On **[IzzyOnDroid repo](https://apt.izzysoft.de/fdroid/index/apk/com.saggitt.omega)**
 
 - **Telegram**: [Neo Applications channel](https://t.me/neo_applications).
 


### PR DESCRIPTION
remove 404 and update IzzyOnDroid to a direct link