### PR TITLE
Add hexagon icon shape option

### DIFF
--- a/Omega/src/com/saggitt/omega/compose/pages/IconShapePage.kt
+++ b/Omega/src/com/saggitt/omega/compose/pages/IconShapePage.kt
@@ -67,6 +67,7 @@ fun IconShapePage() {
             IconShape.Teardrop,
             IconShape.Cylinder,
             IconShape.Cupertino,
+            IconShape.Hexagon,
             IconShape.Octagon,
             IconShape.Egg,
         )

--- a/Omega/src/com/saggitt/omega/icons/IconCornerShape.kt
+++ b/Omega/src/com/saggitt/omega/icons/IconCornerShape.kt
@@ -99,6 +99,42 @@ abstract class IconCornerShape {
         }
     }
 
+    class CutHex : BaseBezierPath() {
+
+        override fun addCorner(
+            path: Path, position: Position, size: PointF, progress: Float,
+            offsetX: Float, offsetY: Float
+        ) {
+            var paddingX = size.x - (size.x * Math.sqrt(3.0) / 2).toFloat()
+            var newOffsetX = offsetX
+
+            if (position is Position.BottomRight) {
+                path.rMoveTo(-paddingX, 0f)
+            }
+
+            if (position is Position.BottomLeft) {
+                newOffsetX += paddingX
+            }
+
+            if (position is Position.TopLeft) {
+                path.setLastPoint(paddingX, size.y)
+            }
+
+            if (position is Position.TopRight) {
+                newOffsetX -= paddingX
+            }
+
+            path.lineTo(
+                position.endX * size.x + newOffsetX,
+                position.endY * size.y + offsetY
+            )
+        }
+
+        override fun toString(): String {
+            return "cuthex"
+        }
+    }
+
     class LightSquircle : BaseBezierPath() {
 
         override val controlDistance = .1f
@@ -294,6 +330,7 @@ abstract class IconCornerShape {
     companion object {
 
         val cut = Cut()
+        val cuthex = CutHex()
         val lightsquircle = LightSquircle()
         val squircle = Squircle()
         val strongsquircle = StrongSquircle()
@@ -305,6 +342,7 @@ abstract class IconCornerShape {
         fun fromString(value: String): IconCornerShape {
             return when (value) {
                 "cut" -> cut
+                "cuthex" -> cuthex
                 "lightsquircle" -> lightsquircle
                 "cubic", "squircle" -> squircle
                 "strongsquircle" -> strongsquircle

--- a/Omega/src/com/saggitt/omega/icons/IconShape.kt
+++ b/Omega/src/com/saggitt/omega/icons/IconShape.kt
@@ -326,6 +326,21 @@ open class IconShape(
         }
     }
 
+    object Hexagon : IconShape(
+        IconCornerShape.cuthex,
+        IconCornerShape.cuthex,
+        IconCornerShape.cuthex,
+        IconCornerShape.cuthex,
+        PointF(1f, .5f),
+        PointF(1f, .5f),
+        PointF(1f, .5f),
+        PointF(1f, .5f)
+    ) {
+        override fun toString(): String {
+            return "hexagon"
+        }
+    }
+
     object Octagon : IconShape(
         IconCornerShape.cut,
         IconCornerShape.cut,
@@ -374,6 +389,7 @@ open class IconShape(
             "teardrop" -> Teardrop
             "cylinder" -> Cylinder
             "cupertino" -> Cupertino
+            "hexagon" -> Hexagon
             "octagon" -> Octagon
             "egg" -> Egg
             "" -> Circle

--- a/Omega/src/com/saggitt/omega/icons/ShapeModel.kt
+++ b/Omega/src/com/saggitt/omega/icons/ShapeModel.kt
@@ -41,6 +41,7 @@ class ShapeModel(val shapeName: String) {
             "teardrop" -> TearDropShape
             "cylinder" -> CylinderShape()
             "cupertino" -> RoundedCornerShape(corner = CornerSize(12.dp))
+            "hexagon" -> HexagonShape()
             "octagon" -> CutCornerShape(25)
             "egg" -> Egg
             else -> CircleShape
@@ -149,6 +150,32 @@ class CylinderShape : Shape {
                 size.width / 13, 0.0f,
                 0.0f, size.height * 2 / 7
             )
+            close()
+        })
+    }
+}
+
+class HexagonShape : Shape {
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density
+    ): Outline {
+        val width = size.width
+        val height = size.height
+        val centerX = width / 2
+        val centerY = height / 2
+        val sideLength = Math.min(width, height) / 2
+        val apothem = (sideLength * Math.sqrt(3.0) / 2).toFloat()
+
+        return Outline.Generic(Path().apply {
+            reset()
+            moveTo(centerX, centerY - sideLength)
+            lineTo(centerX + apothem, centerY - sideLength / 2)
+            lineTo(centerX + apothem, centerY + sideLength / 2)
+            lineTo(centerX, centerY + sideLength)
+            lineTo(centerX - apothem, centerY + sideLength / 2)
+            lineTo(centerX - apothem, centerY - sideLength / 2)
             close()
         })
     }


### PR DESCRIPTION
This Pull Request adds an option to set hexagon as custom icons shape. The current implementation of cutting corners for icons wasn't perfectly compatible with this type of shape because in hexagon corners are not symmetrical so it's a little more custom than other shapes but still fits in the current solution.

Settings | Desktop
--- | ---
![Screenshot_20230818-023202](https://github.com/NeoApplications/Neo-Launcher/assets/69125050/1f62e136-459d-4f6f-908f-11844c5f0a41) | ![Screenshot_20230818-023140](https://github.com/NeoApplications/Neo-Launcher/assets/69125050/b25a7323-ad4b-41cf-8b2f-39da418a4081)
