### PR TITLE
Fix compilation

### DIFF
--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -525,7 +525,7 @@ public class DeviceProfile {
         }
 
         if (renderer == null) {
-            renderer = new DotRenderer(size, getShapePath(context,DEFAULT_DOT_SIZE), DEFAULT_DOT_SIZE, dotSize);
+            renderer = new DotRenderer(size, getShapePath(context,DEFAULT_DOT_SIZE), DEFAULT_DOT_SIZE);
             cache.put(size, renderer);
         }
         return renderer;


### PR DESCRIPTION
Since 681ecf884cbe4ac146c6e370b818742c3617fcf5 DotRenderer only takes three arguments.