### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,4 +116,4 @@ The original AOSP Launcher3 code is licensed under the [Apache License, Version 
 
 Copyright © 2025 [Saul Henriquez](https://github.com/saulhdev), [Antonios Hazim](https://github.com/machiav3lli) and [contributors](https://github.com/NeoApplications/Neo-Launcher/graphs/contributors).
 
-![Star History Chart](https://api.star-history.com/svg?repos=NeoApplications/Neo-Launcher&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=NeoApplications/Neo-Launcher&type=Date)


### PR DESCRIPTION
The star history chart in the README currently fails to render because the underlying service relies on the GitHub stargazer API, which has become restricted and is no longer reliable. This change points the chart to a working alternative that needs no API token, restoring the chart for everyone.