### PR TITLE
 fix(folder): resolve blank Cover Mode icon and swipe-up NaN animation crash

### DIFF
--- a/src/com/android/launcher3/dragndrop/FolderAdaptiveIcon.java
+++ b/src/com/android/launcher3/dragndrop/FolderAdaptiveIcon.java
@@ -153,6 +153,20 @@ public class FolderAdaptiveIcon extends AdaptiveIconDrawable {
         icon.drawDot(badgeCanvas);
         badgeCanvas.restore();
 
+        // When Cover Mode is active, render the cover application icon on the drag layer foreground
+        // and bypass the round folder background plate.
+        if (icon.getFolderInfo() != null && icon.getFolderInfo().isCoverMode()) {
+            Drawable cover = icon.getCoverDrawable();
+            if (cover != null) {
+                foregroundCanvas.save();
+                foregroundCanvas.translate(previewShiftX, previewShiftY);
+                cover.setBounds(sTmpRect);
+                cover.draw(foregroundCanvas);
+                foregroundCanvas.restore();
+            }
+            return;
+        }
+
         // Draw foreground
         foregroundCanvas.save();
         foregroundCanvas.translate(previewShiftX, previewShiftY);

--- a/src/com/android/launcher3/folder/FolderAnimationData.kt
+++ b/src/com/android/launcher3/folder/FolderAnimationData.kt
@@ -62,21 +62,27 @@ data class FolderAnimationData(
             val previewBackground = folderIcon.mBackground
 
             // Get items in Preview and their scaling
+            // Get items in Preview and their scaling
             val itemsInPreview: List<View> = getPreviewIconsOnPage(this, 0)
-            val previewScale: Float = folderIcon.layoutRule.scaleForItem(itemsInPreview.size, 0)
+            val numPreviewItems = itemsInPreview.size
+            val previewScale: Float = folderIcon.layoutRule.scaleForItem(numPreviewItems, 0)
             val previewSize: Float = folderIcon.layoutRule.iconSize * previewScale
 
             // Get scale and position of FolderIcon relative to DragLayer
             val folderIconWorkspacePosition = Rect()
-            val scaleRelativeToDragLayer: Float =
+            val rawScaleRelativeToDragLayer: Float =
                 mActivityContext.dragLayer.getDescendantRectRelativeToSelf(
                     folderIcon,
                     folderIconWorkspacePosition,
                 )
+            val scaleRelativeToDragLayer: Float = if (rawScaleRelativeToDragLayer > 0f && !rawScaleRelativeToDragLayer.isNaN() && !rawScaleRelativeToDragLayer.isInfinite()) rawScaleRelativeToDragLayer else 1f
             val scaledFolderRadius: Int = previewBackground.scaledRadius
-            val baseIconSize: Float = getBubbleTextView(itemsInPreview[0]).iconSize.toFloat()
+            val baseIconSize: Float = if (numPreviewItems > 0) getBubbleTextView(itemsInPreview[0]).iconSize.toFloat() else folderIcon.mActivity.deviceProfile.workspaceIconProfile.iconSizePx.toFloat()
+            val safeBaseIconSize = if (baseIconSize > 0f) baseIconSize else 1f
             val initialFolderSize = (scaledFolderRadius * 2) * scaleRelativeToDragLayer
-            val initialFolderScale = previewSize / baseIconSize * scaleRelativeToDragLayer
+            val initialFolderScale = (previewSize / safeBaseIconSize * scaleRelativeToDragLayer).let {
+                if (it <= 0f || it.isNaN() || it.isInfinite()) 1f else it
+            }
 
             // Get offsets for Previews and Content
             val initialPreviewItemOffsetX =
@@ -103,6 +109,8 @@ data class FolderAnimationData(
             val scaledContentHeight = contentAreaHeight.toFloat() * initialFolderScale
             val contentHeightDifference = contentAreaHeight.toFloat() - scaledContentHeight
             val folderRadiusDifference = previewBackground.scaledRadius - previewBackground.radius
+            val computedFolderScale = initialFolderScale / scaleRelativeToDragLayer
+            val safeFolderScale = if (computedFolderScale > 0f && !computedFolderScale.isNaN() && !computedFolderScale.isInfinite()) computedFolderScale else 1f
             /**
              * Background can have a scaled radius in drag and drop mode, so we need to add the
              * difference to keep the preview items centered.
@@ -110,7 +118,7 @@ data class FolderAnimationData(
             return FolderAnimationData(
                 isOpening = isOpening,
                 startScale = if (isOpening) initialFolderScale else 1f,
-                folderScale = initialFolderScale / scaleRelativeToDragLayer,
+                folderScale = safeFolderScale,
                 xDistance = (initialX - layoutParams.x).toFloat(),
                 yDistance = (initialY - layoutParams.y).toFloat(),
                 contentHeightDifference = contentHeightDifference,

--- a/src/com/android/launcher3/folder/FolderAnimationManager.java
+++ b/src/com/android/launcher3/folder/FolderAnimationManager.java
@@ -409,11 +409,13 @@ public class FolderAnimationManager implements FolderAnimationCreator {
             float previewScale = rule.scaleForItem(numItemsInFirstPagePreview, 0);
             float previewSize = rule.getIconSize() * previewScale;
             float baseIconSize = getBubbleTextView(v).getIconSize();
-            float iconScale = previewSize / baseIconSize;
+            float iconScale = baseIconSize > 0 ? previewSize / baseIconSize : 1f;
 
-            final float initialScale = iconScale / folderScale;
+            float safeFolderScale = (folderScale > 0f && !Float.isNaN(folderScale) && !Float.isInfinite(folderScale)) ? folderScale : 1f;
+            final float initialScale = iconScale / safeFolderScale;
             final float finalScale = 1f;
             float scale = mIsOpening ? initialScale : finalScale;
+            if (Float.isNaN(scale) || Float.isInfinite(scale) || scale <= 0f) scale = 1f;
             v.setScaleX(scale);
             v.setScaleY(scale);
 

--- a/src/com/android/launcher3/folder/FolderIcon.java
+++ b/src/com/android/launcher3/folder/FolderIcon.java
@@ -16,6 +16,7 @@
 
 package com.android.launcher3.folder;
 
+import static com.android.launcher3.LauncherSettings.Favorites.DESKTOP_ICON_FLAG;
 import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.ICON_OVERLAP_FACTOR;
 import static com.android.launcher3.folder.ClippedFolderIconLayoutRule.MAX_NUM_ITEMS_IN_PREVIEW;
 import static com.android.launcher3.folder.FolderGridOrganizer.createFolderGridOrganizer;
@@ -54,6 +55,7 @@ import com.android.launcher3.CheckLongPressHelper;
 import com.android.launcher3.DeviceProfile;
 import com.android.launcher3.DropTarget.DragObject;
 import com.android.launcher3.Launcher;
+import com.android.launcher3.LauncherAppState;
 import com.android.launcher3.LauncherSettings;
 import com.android.launcher3.OnAlarmListener;
 import com.android.launcher3.R;
@@ -68,6 +70,7 @@ import com.android.launcher3.dragndrop.DragLayer;
 import com.android.launcher3.dragndrop.DragView;
 import com.android.launcher3.dragndrop.DraggableView;
 import com.android.launcher3.graphics.ThemeManager;
+import com.android.launcher3.icons.BitmapInfo;
 import com.android.launcher3.icons.DotRenderer;
 import com.android.launcher3.logger.LauncherAtom.FromState;
 import com.android.launcher3.logger.LauncherAtom.ToState;
@@ -156,6 +159,7 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
 
     public boolean isCustomIcon = false;
     private GestureHandler mSwipeUpHandler;
+    private Drawable mCoverDrawable;
 
     private static final Property<FolderIcon, Float> DOT_SCALE_PROPERTY
             = new Property<FolderIcon, Float>(Float.TYPE, "dotScale") {
@@ -226,15 +230,16 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
         if (icon.mFolderName.shouldShowLabel()) {
             icon.mFolderName.applyLabel(folderInfo.title);
         }
-        icon.mFolderName.setCompoundDrawablePadding(0);
         FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) icon.mFolderName.getLayoutParams();
         if (folderInfo instanceof DrawerFolderInfo) {
             lp.topMargin = grid.getAllAppsProfile().getIconSizePx() + grid.getAllAppsProfile().getIconDrawablePaddingPx();
+            icon.mFolderName.setCompoundDrawablePadding(grid.getAllAppsProfile().getIconDrawablePaddingPx());
             icon.mBackground = new PreviewBackground(activity.asContext(), true);
             ((DrawerFolderInfo) folderInfo).getAppsStore().registerFolderIcon(icon);
         } else {
             lp.topMargin = grid.getWorkspaceIconProfile().getIconSizePx()
                 + grid.getWorkspaceIconProfile().getIconDrawablePaddingPx();
+            icon.mFolderName.setCompoundDrawablePadding(grid.getWorkspaceIconProfile().getIconDrawablePaddingPx());
         }
         icon.setTag(folderInfo);
         icon.setOnClickListener(activity.getItemOnClickListener());
@@ -262,6 +267,55 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
         }
     }
 
+    /**
+     * Updates and caches the drawable for the first child application when Cover Mode is enabled.
+     * Ensures high-resolution icon data is requested asynchronously from the icon cache if needed.
+     */
+    public void updateCoverDrawable() {
+        if (mInfo != null && mInfo.isCoverMode()) {
+            WorkspaceItemInfo coverInfo = mInfo.getCoverInfo();
+            if (coverInfo != null) {
+                mCoverDrawable = coverInfo.newIcon(getContext(), BitmapInfo.FLAG_THEMED);
+                if (mCoverDrawable != null) {
+                    mCoverDrawable.setCallback(this);
+                }
+                if (coverInfo.getMatchingLookupFlag().isVisuallyLessThan(DESKTOP_ICON_FLAG)) {
+                    LauncherAppState.getInstance(getContext()).getIconCache().updateIconInBackground(
+                            newInfo -> {
+                                if (mInfo != null && mInfo.isCoverMode() && mInfo.getCoverInfo() == newInfo) {
+                                    mCoverDrawable = ((WorkspaceItemInfo) newInfo).newIcon(getContext(), BitmapInfo.FLAG_THEMED);
+                                    if (mCoverDrawable != null) {
+                                        mCoverDrawable.setCallback(this);
+                                    }
+                                    invalidate();
+                                }
+                            }, coverInfo, DESKTOP_ICON_FLAG);
+                }
+            } else {
+                mCoverDrawable = null;
+            }
+        } else {
+            mCoverDrawable = null;
+        }
+    }
+
+    /**
+     * Returns the cached Cover Mode drawable, lazily initializing it if not yet loaded.
+     */
+    public Drawable getCoverDrawable() {
+        if (mCoverDrawable == null && mInfo != null && mInfo.isCoverMode()) {
+            updateCoverDrawable();
+        }
+        return mCoverDrawable;
+    }
+
+    /**
+     * Returns the FolderInfo model associated with this FolderIcon.
+     */
+    public FolderInfo getFolderInfo() {
+        return mInfo;
+    }
+
     public void animateBgShadowAndStroke() {
         mBackground.fadeInBackgroundShadow();
         mBackground.animateBackgroundStroke();
@@ -272,6 +326,15 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
     }
 
     public void getPreviewBounds(Rect outBounds) {
+        if (mInfo != null && mInfo.isCoverMode()) {
+            int iconSize = isInAppDrawer()
+                    ? mActivity.getDeviceProfile().getAllAppsProfile().getIconSizePx()
+                    : mActivity.getDeviceProfile().getWorkspaceIconProfile().getIconSizePx();
+            int left = (getWidth() - iconSize) / 2;
+            int top = getPaddingTop();
+            outBounds.set(left, top, left + iconSize, top + iconSize);
+            return;
+        }
         mPreviewItemManager.recomputePreviewDrawingParams();
         mBackground.getBounds(outBounds);
         // The preview items go outside of the bounds of the background.
@@ -519,17 +582,17 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
      * Keep the notification dot up to date with the sum of all the content's dots.
      */
     public void updateDotInfo() {
-        if (mInfo.isCoverMode()) {
-            WorkspaceItemInfo cover = mInfo.getCoverInfo();
-            if (cover != null) {
-                applyCoverDotState(cover, false);
-                return;
-            }
-        }
         boolean hadDot = mDotInfo.hasDot();
         mDotInfo.reset();
-        for (ItemInfo si : mInfo.getContents()) {
-            mDotInfo.addDotInfo(mActivity.getDotInfoForItem(si));
+        if (mInfo != null && mInfo.isCoverMode()) {
+            WorkspaceItemInfo cover = mInfo.getCoverInfo();
+            if (cover != null) {
+                mDotInfo.addDotInfo(mActivity.getDotInfoForItem(cover));
+            }
+        } else if (mInfo != null) {
+            for (ItemInfo si : mInfo.getContents()) {
+                mDotInfo.addDotInfo(mActivity.getDotInfoForItem(si));
+            }
         }
         boolean isDotted = mDotInfo.hasDot();
         float newDotScale = isDotted ? 1f : 0f;
@@ -627,20 +690,31 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
         super.dispatchDraw(canvas);
 
         if (!mBackgroundIsVisible) return;
-        if (isCustomIcon) {
-            if (mInfo.isCoverMode()) {
-                WorkspaceItemInfo coverInfo = mInfo.getCoverInfo();
-                if (coverInfo != null) {
-                    mFolderName.setTag(coverInfo);
-                    mFolderName.applyIcon(coverInfo);
-                    applyCoverDotState(coverInfo, false);
+
+        // Ensure layout geometry and spring animation parameters are up to date
+        mPreviewItemManager.recomputePreviewDrawingParams();
+
+        // In Cover Mode (or custom icon mode), directly render the full-sized cover application icon
+        // rather than the standard multi-item folder preview bubble and plate background.
+        if (isCustomIcon || (mInfo != null && mInfo.isCoverMode())) {
+            if (mInfo != null && mInfo.isCoverMode()) {
+                if (mCoverDrawable == null) {
+                    updateCoverDrawable();
+                }
+                if (mCoverDrawable != null) {
+                    int iconSize = isInAppDrawer()
+                            ? mActivity.getDeviceProfile().getAllAppsProfile().getIconSizePx()
+                            : mActivity.getDeviceProfile().getWorkspaceIconProfile().getIconSizePx();
+                    int left = (getWidth() - iconSize) / 2;
+                    int top = getPaddingTop();
+                    mCoverDrawable.setBounds(left, top, left + iconSize, top + iconSize);
+                    mCoverDrawable.draw(canvas);
                 }
             }
             mBackground.setStartOpacity(0f);
+            drawDot(canvas);
             return;
         }
-
-        mPreviewItemManager.recomputePreviewDrawingParams();
 
         if (!mBackground.drawingDelegated()) {
             mBackground.drawBackground(canvas);
@@ -661,14 +735,18 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
         if (!mForceHideDot && ((mDotInfo != null && mDotInfo.hasDot()) || mDotScale > 0)) {
             Rect iconBounds = mDotParams.iconBounds;
             // FolderIcon draws the icon to be top-aligned (with padding) & horizontally-centered
-            int iconSize = mActivity.getDeviceProfile().getWorkspaceIconProfile().getIconSizePx();
+            int iconSize = isInAppDrawer()
+                    ? mActivity.getDeviceProfile().getAllAppsProfile().getIconSizePx()
+                    : mActivity.getDeviceProfile().getWorkspaceIconProfile().getIconSizePx();
             iconBounds.left = (getWidth() - iconSize) / 2;
             iconBounds.right = iconBounds.left + iconSize;
             iconBounds.top = getPaddingTop();
             iconBounds.bottom = iconBounds.top + iconSize;
 
-            float iconScale = (float) mBackground.previewSize / iconSize;
-            Utilities.scaleRectAboutCenter(iconBounds, iconScale);
+            if (mInfo == null || !mInfo.isCoverMode()) {
+                float iconScale = (float) mBackground.previewSize / iconSize;
+                Utilities.scaleRectAboutCenter(iconBounds, iconScale);
+            }
 
             // If we are animating to the accepting state, animate the dot out.
             NeoPrefs prefs = NeoPrefs.getInstance();
@@ -687,7 +765,7 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        if (!mInfo.useIconMode() && isInAppDrawer()) {
+        if (isInAppDrawer()) {
             DeviceProfile grid = mActivity.getDeviceProfile();
             int drawablePadding = grid.getAllAppsProfile().getIconDrawablePaddingPx();
 
@@ -737,7 +815,7 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
 
     @Override
     protected boolean verifyDrawable(@NonNull Drawable who) {
-        return mPreviewItemManager.verifyDrawable(who) || super.verifyDrawable(who);
+        return (mCoverDrawable == who) || mPreviewItemManager.verifyDrawable(who) || super.verifyDrawable(who);
     }
 
     private void updatePreviewItems(boolean animate) {
@@ -755,7 +833,7 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
 
     public void onItemsChanged(boolean animate) {
         if (mInfo.isCoverMode()) {
-            onIconChanged();
+            updateCoverDrawable();
         }
         updatePreviewItems(false);
         updateDotInfo();
@@ -773,39 +851,31 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
         DeviceProfile grid = mActivity.getDeviceProfile();
         mFolderName.setTag(null);
 
-        if (mInfo.useIconMode()) {
-            lp.topMargin = 0;
-            if (isInAppDrawer()) {
-                mFolderName.setCompoundDrawablePadding(grid.getAllAppsProfile().getIconDrawablePaddingPx());
-            } else {
-                mFolderName.setCompoundDrawablePadding(grid.getWorkspaceIconProfile().getIconDrawablePaddingPx());
-            }
+        if (isInAppDrawer()) {
+            lp.topMargin = grid.getAllAppsProfile().getIconSizePx() + grid.getAllAppsProfile().getIconDrawablePaddingPx();
+            mFolderName.setCompoundDrawablePadding(grid.getAllAppsProfile().getIconDrawablePaddingPx());
+        } else {
+            lp.topMargin = grid.getWorkspaceIconProfile().getIconSizePx()
+                    + grid.getWorkspaceIconProfile().getIconDrawablePaddingPx();
+            mFolderName.setCompoundDrawablePadding(grid.getWorkspaceIconProfile().getIconDrawablePaddingPx());
+        }
 
+        mFolderName.clearIcon();
+        mFolderName.applyLabel(mFolder != null ? mInfo.getIconTitle(mFolder) : mInfo.title);
+
+        if (mInfo.useIconMode()) {
             isCustomIcon = true;
-            if (mInfo.isCoverMode()) {
-                WorkspaceItemInfo coverInfo = mInfo.getCoverInfo();
-                if (coverInfo != null) {
-                    mFolderName.setTag(coverInfo);
-                    mFolderName.applyIcon(coverInfo);
-                    applyCoverDotState(coverInfo, false);
-                }
-            }
+            updateCoverDrawable();
             mBackground.setStartOpacity(0f);
         } else {
             isCustomIcon = false;
-            if (isInAppDrawer()) {
-                lp.topMargin = grid.getAllAppsProfile().getIconSizePx() + grid.getAllAppsProfile().getIconDrawablePaddingPx();
-            } else {
-                lp.topMargin = grid.getWorkspaceIconProfile().getIconSizePx()
-                        + grid.getWorkspaceIconProfile().getIconDrawablePaddingPx();
-            }
-
-            mFolderName.applyDotState(mInfo, false);
-            mFolderName.clearIcon();
+            mCoverDrawable = null;
             mBackground.setStartOpacity(1f);
         }
-        mFolderName.applyLabel(mInfo.title);
+
+        updateDotInfo();
         requestLayout();
+        invalidate();
     }
 
     public void applyCoverDotState(ItemInfo itemInfo, boolean animate) {
@@ -985,18 +1055,17 @@ public class FolderIcon extends FrameLayout implements FloatingIconViewCompanion
 
     public void updateIconDots(Predicate<PackageUserKey> updatedBadges, PackageUserKey tmpKey) {
         FolderDotInfo folderDotInfo = new FolderDotInfo();
-        for (ItemInfo si : mInfo.contents) {
-            folderDotInfo.addDotInfo(mActivity.getDotInfoForItem(si));
-        }
-        setDotInfo(folderDotInfo);
-
-        if (mInfo.isCoverMode()) {
+        if (mInfo != null && mInfo.isCoverMode()) {
             WorkspaceItemInfo coverInfo = getCoverInfo();
-            if (tmpKey.updateFromItemInfo(coverInfo) &&
-                    updatedBadges.test(tmpKey)) {
-                applyCoverDotState(coverInfo, true);
+            if (coverInfo != null) {
+                folderDotInfo.addDotInfo(mActivity.getDotInfoForItem(coverInfo));
+            }
+        } else if (mInfo != null) {
+            for (ItemInfo si : mInfo.contents) {
+                folderDotInfo.addDotInfo(mActivity.getDotInfoForItem(si));
             }
         }
+        setDotInfo(folderDotInfo);
     }
     /**
      * Interface that provides callbacks to a parent ViewGroup that hosts this FolderIcon.

--- a/src/com/android/launcher3/folder/IconAnimationData.kt
+++ b/src/com/android/launcher3/folder/IconAnimationData.kt
@@ -77,10 +77,19 @@ data class IconAnimationData(
                 val previewIconScale = layoutRule.scaleForItem(numItemsOnPage, page)
                 val previewIconSize = layoutRule.iconSize * previewIconScale
                 val baseIconSize = getBubbleTextView(currentIcon).iconSize.toFloat()
-                val iconScale = previewIconSize / baseIconSize
+                val iconScale = if (baseIconSize > 0f) previewIconSize / baseIconSize else 1f
 
-                // Scale when folder closed
-                val initialIconScale = iconScale / folderAnimationData.folderScale
+                // Protect against zero division and NaN/infinite scale values during spring animations
+                val safeFolderScale = if (folderAnimationData.folderScale > 0f && !folderAnimationData.folderScale.isNaN() && !folderAnimationData.folderScale.isInfinite()) {
+                    folderAnimationData.folderScale
+                } else {
+                    1f
+                }
+
+                // Scale when folder closed; clamp to valid finite scale to avoid IllegalArgumentException in View.setScaleX/Y
+                val initialIconScale = (iconScale / safeFolderScale).let {
+                    if (it <= 0f || it.isNaN() || it.isInfinite()) 1f else it
+                }
                 // Scale when folder open
                 val finalIconScale = 1f
                 // Scale to start with in Animation
@@ -106,12 +115,12 @@ data class IconAnimationData(
                 // Calculate positions for each icon
                 val iconPositionX =
                     ((mTmpParams.transX - iconOffsetX + folderAnimationData.scaledPreviewOffsetX) /
-                            folderAnimationData.folderScale)
+                            safeFolderScale)
                         .toInt()
                 val paddingTop = currentIcon.paddingTop * iconScale
                 val iconPositionY =
                     ((mTmpParams.transY + folderAnimationData.folderRadiusDifference - paddingTop) /
-                            folderAnimationData.folderScale)
+                            safeFolderScale)
                         .toInt()
                 val xDistance = (iconPositionX - iconLayoutParams.x).toFloat()
                 val yDistance = (iconPositionY - iconLayoutParams.y).toFloat()

--- a/src/com/android/launcher3/folder/PreviewItemManager.java
+++ b/src/com/android/launcher3/folder/PreviewItemManager.java
@@ -144,10 +144,24 @@ public class PreviewItemManager {
         return animateDrawable;
     }
 
+    /**
+     * Recomputes preview layout and animation geometry.
+     * When mReferenceDrawable is null (such as in Cover Mode or before child views are bound),
+     * falls back to the DeviceProfile icon size to guarantee previewLayoutRule is properly initialized
+     * and prevent NaN scale calculations during folder spring animations.
+     */
     public void recomputePreviewDrawingParams() {
         if (mReferenceDrawable != null) {
             computePreviewDrawingParams(mReferenceDrawable.getIntrinsicWidth(),
                     mIcon.getMeasuredWidth());
+        } else if (mIcon != null && mIcon.mActivity != null && mIcon.mActivity.getDeviceProfile() != null) {
+            int iconSize = mIcon.isInAppDrawer()
+                    ? mIcon.mActivity.getDeviceProfile().getAllAppsProfile().getIconSizePx()
+                    : mIcon.mActivity.getDeviceProfile().getWorkspaceIconProfile().getIconSizePx();
+            int totalWidth = mIcon.getMeasuredWidth() > 0 ? mIcon.getMeasuredWidth() : iconSize;
+            if (iconSize > 0 && totalWidth > 0) {
+                computePreviewDrawingParams(iconSize, totalWidth);
+            }
         }
     }
 

--- a/src/com/android/launcher3/model/data/FolderInfo.java
+++ b/src/com/android/launcher3/model/data/FolderInfo.java
@@ -43,6 +43,7 @@ import com.android.launcher3.LauncherSettings;
 import com.android.launcher3.R;
 import com.android.launcher3.folder.Folder;
 import com.android.launcher3.folder.FolderNameInfos;
+import com.android.launcher3.icons.BitmapInfo;
 import com.android.launcher3.icons.BitmapRenderer;
 import com.android.launcher3.logger.LauncherAtom;
 import com.android.launcher3.logger.LauncherAtom.Attribute;
@@ -179,6 +180,9 @@ public class FolderInfo extends CollectionInfo {
         onIconChanged();
     }
 
+    /**
+     * Retrieves the first application item contained in the folder to act as the cover item.
+     */
     @Nullable
     public WorkspaceItemInfo getCoverInfo() {
         for (ItemInfo item : getContents()) {
@@ -187,11 +191,15 @@ public class FolderInfo extends CollectionInfo {
         return null;
     }
 
+    /**
+     * Returns the icon drawable for this folder.
+     * When Cover Mode is active, returns the themed icon of the first child app.
+     */
     public Drawable getIcon(Context context) {
         Launcher launcher = Launcher.getLauncher(context);
         if (isCoverMode()) {
             WorkspaceItemInfo cover = getCoverInfo();
-            return cover != null ? cover.newIcon(context) : null;
+            return cover != null ? cover.newIcon(context, BitmapInfo.FLAG_THEMED) : null;
         }
         return getFolderIcon(launcher);
     }
@@ -210,16 +218,22 @@ public class FolderInfo extends CollectionInfo {
         return new BitmapDrawable(launcher.getResources(), b);
     }
 
+    /**
+     * Returns the appropriate title to display for this folder on the workspace.
+     * Handles null folders and empty coverInfo safely.
+     */
     public CharSequence getIconTitle(Folder folder) {
         if (!isCoverMode()) {
-            if (!TextUtils.equals(folder.getDefaultFolderName(), title)) {
+            if (folder != null && !TextUtils.equals(folder.getDefaultFolderName(), title)) {
                 return title;
-            } else {
+            } else if (folder != null) {
                 return folder.getDefaultFolderName();
+            } else {
+                return title;
             }
         } else {
             WorkspaceItemInfo info = getCoverInfo();
-            return info.title;
+            return info != null && info.title != null ? info.title : title;
         }
     }
 

--- a/src/com/android/launcher3/util/LauncherBindableItemsContainer.kt
+++ b/src/com/android/launcher3/util/LauncherBindableItemsContainer.kt
@@ -46,6 +46,14 @@ interface LauncherBindableItemsContainer {
                     v.applyFromWorkspaceItem(info)
                 v is FolderIcon && info is FolderInfo -> {
                     v.updatePreviewItems(updates::contains)
+                    // If an icon update affects the folder's cover item, reload the cover drawable immediately
+                    if (info.isCoverMode) {
+                        val cover = info.coverInfo
+                        if (cover != null && updates.contains(cover)) {
+                            v.updateCoverDrawable()
+                            v.invalidate()
+                        }
+                    }
                     if (updates.contains(info)) {
                         v.onItemsChanged(false)
                         v.folder.apply {


### PR DESCRIPTION
Fixes #564 

### 📌 Summary of Changes
This pull request resolves two critical issues affecting **Cover Mode** on application folders:
1. **Blank / Invisible Folder Icons**: When enabling Cover Mode on home screen or drawer folders, the icon rendered blank/invisible because the launcher attempted to force child `BubbleTextView` (`mFolderName`) to render compound drawables with `topMargin = 0`, causing vertical double-centering padding offsets, suppression in the Hotseat / Dock when `setTextVisible(false)` was invoked, and drawing invalidation races.
2. **Crash on Swiping Up (`Float.NaN`)**: Swiping up on a Cover Mode folder to expand it threw an unhandled `java.lang.IllegalArgumentException: Cannot set 'scaleX' to Float.NaN` because `recomputePreviewDrawingParams()` was bypassed in Cover Mode, leaving layout geometry uninitialized (`mPreviewLayoutRule.mIconSize = 0f`) and causing `0 / 0 = Float.NaN` during spring open animations.
---
### 🔍 Root Cause Analysis
1. **Drawing Architecture Mismatch (`FolderIcon.java`)**:
   `FolderIcon` wraps a `BubbleTextView` child (`mFolderName`) which is positioned and structured to draw only the text label beneath the folder. Attempting to force `BubbleTextView` to render the cover icon resulted in visual displacements and dock invisibility.
2. **Bypassed Layout Metric Recomputation (`PreviewItemManager.java`)**:
   In Cover Mode, preview item rendering was skipped, leaving `mReferenceDrawable == null`. `recomputePreviewDrawingParams()` did not execute fallback initialization, causing `mPreviewLayoutRule.mIconSize` and `mBaselineIconScale` to remain `0f`.
3. **Unchecked Zero/NaN Division in Spring Animators (`IconAnimationData.kt`, `FolderAnimationData.kt`, `FolderAnimationManager.java`)**:
   When calculating `initialIconScale = (previewSize / baseIconSize) / folderScale`, uninitialized preview dimensions evaluated to `0 / 0 = Float.NaN`, crashing Android's `View.setScaleX()` / `View.setScaleY()`.
4. **Null Pointer Exception in Title Resolution (`FolderInfo.java`)**:
   `FolderInfo.getIconTitle()` called `getCoverInfo().title` without checking if `getCoverInfo()` was null.
---
### 🛠️ Key Changes by Component
- **`FolderIcon.java`**:
  - Direct canvas rendering: Added cached `mCoverDrawable` and rendered it directly onto the `FolderIcon` canvas in `dispatchDraw()` at standard launcher icon coordinates `((getWidth() - iconSize) / 2, getPaddingTop())`.
  - Asynchronous high-res icon resolution: Implemented `updateCoverDrawable()` with async fallback to `IconCache.updateIconInBackground()`.
  - Label layout alignment: Standardized `BubbleTextView` margin (`topMargin = iconSize + iconDrawablePaddingPx`) and cleared compound drawables from `mFolderName`.
  - Geometry & touch bounds: Updated `drawDot()` and `getPreviewBounds()` to use full icon dimensions instead of scaled preview circles when in Cover Mode.
  - Continuous geometry refresh: Moved `mPreviewItemManager.recomputePreviewDrawingParams()` ahead of the Cover Mode branch in `dispatchDraw()`.
- **`PreviewItemManager.java`**:
  - Added fallback to `DeviceProfile.iconSizePx` in `recomputePreviewDrawingParams()` when `mReferenceDrawable` is null, ensuring `mPreviewLayoutRule` is always initialized.
- **`IconAnimationData.kt` & `FolderAnimationData.kt`**:
  - Added safety clamping for `safeFolderScale`, `iconScale`, and `startScale` to prevent `Float.NaN`, `Float.POSITIVE_INFINITY`, or non-positive scales from reaching `View.setScaleX()` / `View.setScaleY()`.
- **`FolderAnimationManager.java`**:
  - Added NaN and zero-division guards to the legacy folder animation manager.
- **`FolderInfo.java`**:
  - Added null safety checks in `getIconTitle()` when `getCoverInfo()` is null.
  - Requested themed icon support (`BitmapInfo.FLAG_THEMED`) for cover items.
- **`FolderAdaptiveIcon.java`**:
  - Rendered `icon.getCoverDrawable()` directly into `foregroundCanvas` on the drag layer, skipping the round folder background plate.
- **`LauncherBindableItemsContainer.kt`**:
  - Added dynamic cover icon invalidation and reloading when container updates include the folder's cover item.
---
### 🧪 Verification & Testing
- **Compilation**: Clean Gradle build via `./gradlew assembleAospOmegaDebug` with 0 Kotlin/Java errors.
- **Hardware Tested**: Verified on **Samsung Galaxy A54 5G (`SM-A546U`, Android 16 / SDK 36)**:
  - [x] Cover Mode folder icons display the first application icon sharply (including themed icons).
  - [x] Folder label renders cleanly below the icon.
  - [x] Tapping the folder icon directly launches the first application.
  - [x] Swiping up on the folder smoothly expands the folder popup with 0 crashes.
  - [x] Dragging a Cover Mode folder displays the application icon shadow preview.
  - [x] Placing a Cover Mode folder in the Hotseat / Dock retains the visible icon while hiding the label.