### PR TITLE
Stop hiding widgets that are off the current page

### DIFF
--- a/src/com/android/launcher3/widget/WidgetVisibilityTracker.kt
+++ b/src/com/android/launcher3/widget/WidgetVisibilityTracker.kt
@@ -17,14 +17,10 @@
 package com.android.launcher3.widget
 
 import android.view.View
-import androidx.core.util.forEach
-import com.android.launcher3.AbstractFloatingView
-import com.android.launcher3.AbstractFloatingView.TYPE_ALL
 import com.android.launcher3.Launcher
 import com.android.launcher3.LauncherState
 import com.android.launcher3.PagedView
 import com.android.launcher3.Workspace
-import com.android.launcher3.model.data.LauncherAppWidgetInfo
 import com.android.launcher3.statemanager.StateManager
 import com.android.launcher3.views.ActivityContext
 
@@ -60,23 +56,24 @@ class WidgetVisibilityTracker(
     }
 
     private fun updateVisibility() {
-        val inNormalState = stateManager.currentStableState == LauncherState.NORMAL
-        val noFloatingViews =
-            AbstractFloatingView.getAnyView<AbstractFloatingView>(activityContext, TYPE_ALL) == null
-        val visiblePages = workspace.visiblePageIndices
-        widgetHolder.views.forEach { _, view ->
-            val pageIndex =
-                (view.tag as? LauncherAppWidgetInfo)?.screenId?.let {
-                    workspace.getPageIndexForScreenId(it)
-                } ?: return@forEach
-            if (inNormalState && noFloatingViews && pageIndex in visiblePages) {
-                view.visibility = View.VISIBLE
-                //view.startVisibilityTracking()
-            } else {
-                view.visibility = View.GONE
-                //view.stopVisibilityTracking()
-            }
-        }
+        // AOSP tells each widget whether it is on screen through
+        // AppWidgetHostView.startVisibilityTracking() / stopVisibilityTracking(). That is a hint
+        // to the provider, and it leaves the view in place. Both methods are public since
+        // SDK 36.1, but they are missing from prebuilt/libs/framework-16.jar, which comes ahead
+        // of the SDK android.jar on the compile classpath, so they cannot be called from here
+        // yet.
+        //
+        // They had been replaced with View.GONE / View.VISIBLE. That is not equivalent: a GONE
+        // view is neither laid out nor drawn. And since this method only runs once a page switch
+        // has been committed, at the end of the scroll, two defects followed:
+        //   - widgets on the incoming page were not drawn for the whole page transition, then
+        //     popped in at once;
+        //   - any open floating view hid every widget, and the resize frame is one, so the
+        //     widget being resized vanished and stopped being laid out -- its frame stayed at
+        //     the size it had when the resize started, until the frame was dismissed.
+        //
+        // So leave view visibility alone. The hint can come back exactly as AOSP writes it once
+        // the prebuilt framework jar carries the API.
     }
 
     fun destroy() {


### PR DESCRIPTION
`WidgetVisibilityTracker` hides widgets with `View.GONE` instead of using the AOSP visibility hints. That breaks widget rendering during every page transition, and while a widget is being resized.

### What happens

`updateVisibility()` was written to call `AppWidgetHostView.startVisibilityTracking()` / `stopVisibilityTracking()` — hints to the provider that leave the view in the hierarchy. Both are public since SDK 36.1 but are missing from `prebuilt/libs/framework-16.jar`, which comes ahead of the SDK `android.jar` on the compile classpath, so the calls were commented out and replaced with `View.GONE` / `View.VISIBLE`.

A `GONE` view is neither laid out nor drawn, and `updateVisibility()` only runs once a page switch has been committed — at the end of the scroll. Two defects follow.

**Widgets are missing during every page transition.** The incoming page keeps its widgets `GONE` for the whole scroll, and they pop in when it ends. Frame-by-frame captures make the asymmetry obvious: the outgoing page keeps its widgets while it slides away, the incoming page shows bare wallpaper until the scroll settles. With a real swipe that is roughly a second of empty space, on every page change.

**The resize frame hides the widget it is resizing.** Any open floating view clears `noFloatingViews`, and `AppWidgetResizeFrame` is one. The widget disappears; `ShortcutAndWidgetContainer.onLayout()` then skips it because it is `GONE`, so it is never laid out again. The frame keeps the size it had when the resize started, and the widget only takes its new size once the frame is dismissed. Long-pressing a widget makes it vanish entirely, leaving the frame handles floating over the wallpaper.

A stack trace from the device, taken during a swipe:

```
ShortcutAndWidgetContainer.requestLayout
  View.setVisibility
    WidgetVisibilityTracker.updateVisibility
      WidgetVisibilityTracker.onPageSwitch
        PagedView.notifyPageSwitchListener
          PagedView.computeScrollHelper
```

### The change

Leave view visibility alone. This restores the behaviour from before the tracker was introduced. The hint can come back exactly as AOSP writes it once the prebuilt framework jar carries the API, so the class and its listeners are left in place for that.

That does leave `updateVisibility()` empty and two constructor properties unused. Happy to delete the class instead, or to bump the prebuilt framework jar so the real calls compile, if you would rather go either of those ways.

### Verified on

Pixel 6, Android 17 (SDK 37), `aospOmega` release build. Screen recordings before and after confirm the incoming page now keeps its widgets drawn throughout the transition, and resizing follows the requested size.
