### PR TITLE
Refresh the disabled icon state when only runtime flags change

### DIFF
--- a/src/com/android/launcher3/BubbleTextView.java
+++ b/src/com/android/launcher3/BubbleTextView.java
@@ -537,6 +537,12 @@ public class BubbleTextView extends TextView implements ItemInfoUpdateReceiver,
         if (hasPendingAnimationCompleted(mIcon) || !mIcon.isSameInfo(info.bitmap)) {
             setNonPendingIcon(info);
         }
+        // The disabled look is only baked in by newIcon() when the drawable is created. When the
+        // drawable above is reused -- the bitmap did not change, only the runtime flags did,
+        // which is exactly what happens when the system suspends or un-suspends an app --
+        // nothing else refreshes it, and the icon keeps whatever state it was created with.
+        // Re-syncing here is a no-op when the state already matches.
+        setIconDisabled(info.isDisabled());
         applyLabel(info);
         maybeApplyProgressLevel(info, oldIcon);
     }


### PR DESCRIPTION
App icons that were greyed out while their app was suspended stay grey after the app is un-suspended, until the launcher is recreated — in practice, until the device reboots.

### What happens

`ItemInfoWithIcon.newIcon()` applies `drawable.setDisabled(isDisabled())` when the `FastBitmapDrawable` is created, and nothing applies it afterwards. `BubbleTextView.applyIconAndLabel()` reuses the existing drawable whenever the `BitmapInfo` is the same instance:

```java
if (hasPendingAnimationCompleted(mIcon) || !mIcon.isSameInfo(info.bitmap)) {
    setNonPendingIcon(info);
}
```

`isSameInfo()` is an identity check on the `BitmapInfo`. Suspending or un-suspending an app changes only `runtimeStatusFlags`: `PackageTaskFactory` flips `FLAG_DISABLED_SUSPENDED` and rebinds the item, the bitmap object is untouched, so the drawable is not recreated and its greyed-out state is never refreshed.

Battery saver makes this easy to hit. It pauses apps and flips the system theme, the launcher gets recreated, icons are then built greyed-out — correctly — and afterwards nothing ever brings them back to colour.

Before the drawable reuse was introduced, `applyIconAndLabel()` called `newIcon()` unconditionally, so the state was rebuilt on every apply and the problem could not appear.

### The change

Re-sync the state on every apply. `BubbleTextView.setIconDisabled()` already exists for exactly this, but had no caller outside `PredictedAppIcon`, which does the same re-sync in `setItemInfo()`. The call is a no-op when the state already matches.

### Note

I have not managed to drive a full battery-saver suspend / un-suspend cycle to confirm this end to end. The analysis above comes from reading the code path, and the fix mirrors what `PredictedAppIcon` already does; the build itself is running on a Pixel 6 with Android 17.
